### PR TITLE
feat: Add command bin/rails generate maintenance_tasks:install

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,10 @@ https://github.com/user-attachments/assets/057c75ce-7c8e-4c89-a238-13546b5797f1
 ## 使い方
 
 1. `bundle add scriptor`
-2. config/routes.rb に `mount Scriptor::Engine => "/scriptor"` を記載
-3. scriptフォルダにスクリプトを作る
+2. `bin/rails generate maintenance_tasks:install` を実行
+    - `config/routes.rb` に `mount Scriptor::Engine => "/scriptor"` が記載されます
+    - `db/migrations/****_create_scriptor_executions.scriptor.rb` ファイルが作成されます
+3. scriptフォルダにスクリプトを作ると、/scriptor ページにスクリプト一覧が並びます
 
 で完成です。
 

--- a/lib/generators/scriptor/install_generator.rb
+++ b/lib/generators/scriptor/install_generator.rb
@@ -1,0 +1,16 @@
+module Scriptor
+  class InstallGenerator < Rails::Generators::Base
+    desc "Install Scriptor"
+
+    # Mounts the engine in the host application's config/routes.rb
+    def mount_engine
+      route("mount Scriptor::Engine, at: \"/scriptor\"")
+    end
+
+    # Copies engine migrations to host application and migrates the database
+    def install_migrations
+      rake("scriptor:install:migrations")
+      rake("db:migrate")
+    end
+  end
+end


### PR DESCRIPTION
## 📋 概要

- migrationファイルを作る
- routes.rbにScriptor::Engineをmountする

ことができるgeneratorを作成しました。

## 📸 スクリーンショット

`bin/rails generate scriptor:install` で実行可能です。

例) 
```ruby
 bin/rails generate scriptor:install    
       route  mount Scriptor::Engine, at: "/scriptor"
        rake  scriptor:install:migrations
Copied migration 20241219132648_create_scriptor_executions.scriptor.rb from scriptor
        rake  db:migrate
== 20241219132648 CreateScriptorExecutions: migrating =========================
-- create_table(:scriptor_executions)
   -> 0.0017s
== 20241219132648 CreateScriptorExecutions: migrated (0.0017s) ================

Annotating models
Model files unchanged.
```


## 📮 レビュワーに伝えたいこと
<!-- 観点、ポイント、不明点、疑問点など -->
